### PR TITLE
remove build scripts for heroku compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
   ],
   "scripts": {
     "start": "NODE_ENV=production MINERANKER_API_URL=https://mineranker.herokuapp.com node app.js",
-    "build": "echo no_build",
     "compile:app": "webpack -r dotenv/config --progress --profile --colors --display-error-details --display-cached",
     "compile:app:watch": "MINERANKER_API_URL=http://localhost:10010 webpack-dev-server -r dotenv/config --hot --inline --watch --progress --profile --colors --display-error-details --display-cached --content-base build/mineranker",
     "dev": "nodemon -w api --exec \"NODE_ENV=dev babel-node app.js --presets es2015,stage-0\"",
@@ -115,7 +114,6 @@
     "edit": "swagger project edit",
     "flow": "flow check",
     "lint:app": "eslint app/",
-    "postinstall": "npm run build",
     "test":  "find ./test/ -name '*.js' | xargs mocha -R spec",
     "test:app": "npm run flow && npm run lint:app && npm run test:unit",
     "test:unit": "jest",


### PR DESCRIPTION
This should close #5
The problem was  the `"postinstall": "npm run build"` part - it requested heroku to run `npm run build` after installation, which failed the whole installation process.
Heroku should now build the app with yarn without problems